### PR TITLE
🏰 chore(readme): update GitHub Actions badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-[![📦 Packing](https://github.com/guotingchao/CuteToyTools/actions/workflows/TCR.yml/badge.svg)](https://github.com/guotingchao/CuteToyTools/actions/workflows/TCR.yml)
+[![📦 Packing](https://github.com/bytesbeats/CuteToy/actions/workflows/push-image.yml/badge.svg)](https://github.com/bytesbeats/CuteToy/actions/workflows/push-image.yml)
 
 </div>
 


### PR DESCRIPTION
• Change the badge link to reflect the new repository URL

This update ensures that the README displays the correct status of the
GitHub Actions workflow for the project, improving clarity for users.
